### PR TITLE
Improve example workflow to delete cache entries for closed PRs

### DIFF
--- a/content/actions/using-workflows/caching-dependencies-to-speed-up-workflows.md
+++ b/content/actions/using-workflows/caching-dependencies-to-speed-up-workflows.md
@@ -344,17 +344,11 @@ on:
 jobs:
   cleanup:
     runs-on: ubuntu-latest
-    steps:
-      - name: Check out code
-        uses: {% data reusables.actions.action-checkout %}
-        
+    steps:      
       - name: Cleanup
         run: |
           gh extension install actions/gh-actions-cache
           
-          REPO={% raw %}${{ github.repository }}{% endraw %}
-          BRANCH="refs/pull/{% raw %}${{ github.event.pull_request.number }}{% endraw %}/merge"
-
           echo "Fetching list of cache key"
           cacheKeysForPR=$(gh actions-cache list -R $REPO -B $BRANCH -L 100 | cut -f 1 )
 
@@ -368,6 +362,8 @@ jobs:
           echo "Done"
         env:
           GH_TOKEN: {% raw %}${{ secrets.GITHUB_TOKEN }}{% endraw %}
+          REPO: {% raw %}${{ github.repository }}{% endraw %}
+          BRANCH: refs/pull/{% raw %}${{ github.event.pull_request.number }}{% endraw %}/merge
 ```
 
 Alternatively, you can use the API to automatically list or delete all caches on your own cadence. For more information, see "[AUTOTITLE](/rest/actions/cache#about-the-cache-in-github-actions)."


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:

The example workflow for deleting cache entries when the relevant PR has been closed has extra unnecessary logic which we can remove.

<!-- If there's an existing issue for your change, please link to it above.
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed (if available, include any code snippets, screenshots, or gifs):

This PR removes an unnecessary checkout step from the workflow and makes the environment variable declaration more consistent.

This version is being used successfully here: https://github.com/noir-lang/noir/blob/master/.github/workflows/cache-cleanup.yml

### Check off the following:

- [ ] I have reviewed my changes in staging, available via the **View deployment** link in this PR's timeline.

  - For content changes, you will also see an automatically generated comment with links directly to pages you've modified. The comment won't appear if your PR only edits files in the `data` directory.
- [ ] For content changes, I have completed the [self-review checklist](https://github.com/github/docs/blob/main/contributing/self-review.md#self-review).
